### PR TITLE
Fix for access request on iOS 6

### DIFF
--- a/motion/address_book.rb
+++ b/motion/address_book.rb
@@ -21,7 +21,7 @@ module AddressBook
   end
 
   def request_authorization(&block)
-    synchronous = !!block
+    synchronous = !block
     access_callback = lambda { |granted, error|
       # not sure what to do with error ... so we're ignoring it
       @address_book_access_granted = granted


### PR DESCRIPTION
There are 2 issues cause apps use motion-addressbook crash on iOS 6 devices, they got fixed in 2 commits separately.

Now request access manually works properly on iOS 6, however the simplest usage `people = AddressBook::Person.all` still raise exception if user decide to not allow access, since call to `ABAddressBookCopyArrayOfAllPeople` on this line https://github.com/alexrothenberg/motion-addressbook/blob/master/motion/address_book/person.rb#L17 will return `nil`.

Maybe in README we should suggest developers to use manual way only.
