### PR TITLE
AddressBook::Person now fetches the unique record id and stores it.

### DIFF
--- a/motion/address_book/person.rb
+++ b/motion/address_book/person.rb
@@ -1,6 +1,6 @@
 module AddressBook
   class Person
-    attr_reader :attributes, :error, :ab_person
+    attr_reader :uid, :attributes, :error, :ab_person
 
     def initialize(attributes={}, existing_ab_person = nil)
       @attributes = attributes
@@ -8,6 +8,7 @@ module AddressBook
         @new_record = true
       else
         @ab_person = existing_ab_person
+        set_uid
         load_ab_person
         @new_record = false
       end
@@ -35,6 +36,7 @@ module AddressBook
       ABAddressBookSave(address_book, error )
       @address_book = nil #force refresh
       @new_record = false
+      set_uid
     end
 
     def self.where(conditions)
@@ -135,7 +137,11 @@ module AddressBook
       set_field(attribute_map[attribute_name.to_sym], value)
       attributes[attribute_name.to_sym] = value
     end
-
+    
+    def self.find_by_uid(criteria)
+      find_by :uid, criteria
+    end
+    
     def self.find_all_by(attribute_name, criteria)
       where({attribute_name.to_sym => criteria})
     end
@@ -221,7 +227,11 @@ module AddressBook
       set_multi_field(KABPersonPhoneProperty,  :mobile => attributes[:mobile_phone], :work => attributes[:office_phone])
       set_multi_field(KABPersonEmailProperty,  :work => attributes[:email])
     end
-
+    
+    def set_uid
+      @uid = ABRecordGetRecordID @ab_person
+    end
+    
     def set_field(field, value)
       ABRecordSetValue(ab_person, field, value, error)
     end

--- a/spec/address_book/person_spec.rb
+++ b/spec/address_book/person_spec.rb
@@ -17,11 +17,22 @@ describe AddressBook::Person do
         @email = unique_email
         @alex = AddressBook::Person.create(:first_name => 'Alex', :last_name => 'Testy', :email => @email)
       end
-      describe '.find_by_all_email' do
+      describe '.find_by_uid' do
+        it 'should find match' do
+          @alex.uid.should.not.be.nil
+          alex = AddressBook::Person.find_by_uid @alex.uid
+          alex.uid.should == @alex.uid
+          alex.email.should == @email
+          alex.first_name.should == 'Alex'
+          alex.last_name.should  == 'Testy'
+        end
+      end
+      describe '.find_all_by_email' do
         it 'should find matches' do
           alexes = AddressBook::Person.find_all_by_email @email
           alexes.should.not.be.empty
           alexes.each do |alex|
+            alex.uid.should != nil
             alex.email.should == @email
             alex.first_name.should == 'Alex'
             alex.last_name.should  == 'Testy'
@@ -35,6 +46,7 @@ describe AddressBook::Person do
       describe '.find_by_email' do
         it 'should find match' do
           alex = AddressBook::Person.find_by_email @email
+          alex.uid.should.not.be.nil
           alex.email.should == @email
           alex.first_name.should == 'Alex'
           alex.last_name.should  == 'Testy'
@@ -49,6 +61,7 @@ describe AddressBook::Person do
           alexes = AddressBook::Person.where(:email => @email)
           alexes.should.not.be.empty
           alexes.each do |alex|
+            alex.uid.should != nil
             alex.email.should == @email
             alex.first_name.should == 'Alex'
             alex.last_name.should  == 'Testy'
@@ -84,6 +97,7 @@ describe AddressBook::Person do
       it 'should find an existing person' do
         alex = AddressBook::Person.find_or_new_by_email(@email)
         alex.should.not.be.new_record
+        alex.uid.should != nil
         alex.email.should      == @email
         alex.first_name.should == 'Alex'
         alex.last_name.should  == 'Testy'
@@ -92,6 +106,7 @@ describe AddressBook::Person do
         never_before_used_email = unique_email
         alex = AddressBook::Person.find_or_new_by_email(never_before_used_email)
         alex.should.be.new_record
+        alex.uid.should == nil
         alex.email.should == never_before_used_email
         alex.first_name.should == nil
       end
@@ -147,7 +162,7 @@ describe AddressBook::Person do
           @ab_person.organization.should.equal 'new organization'
         end
 
-        it 'should be able to set the phot' do
+        it 'should be able to set the photo' do
           image = CIImage.emptyImage
           data = UIImagePNGRepresentation(UIImage.imageWithCIImage image)
           @ab_person.photo = data
@@ -235,6 +250,9 @@ describe AddressBook::Person do
         @person.setter?('first_name'       ).should.be falsey
         @person.setter?('find_all_by_email').should.be falsey
         @person.setter?('find_by_email'    ).should.be falsey
+      end
+      it 'should not have a setter for uid' do
+        @person.setter?('uid=').should.be falsey
       end
     end
     describe 'all_finders' do


### PR DESCRIPTION
When trying to find an existing contact, it makes more sense to be able to search by the unique record id created for that contact in the Address Book. It's guaranteed to be unique.

http://developer.apple.com/library/ios/#documentation/AddressBook/Reference/ABRecordRef_iPhoneOS/Reference/reference.html#//apple_ref/c/func/ABRecordGetRecordID

AddressBook::Person now fetches the unique record id and stores it as @uid. Also added a .find_by_uid(uid) method.
