### PR TITLE
Prevents crash in REPL when calling person.photo by having person.photo return a UIImage

### DIFF
--- a/motion/address_book/person.rb
+++ b/motion/address_book/person.rb
@@ -199,7 +199,8 @@ module AddressBook
     end
 
     def photo
-      ABPersonCopyImageData(ab_person)
+      abpd = ABPersonCopyImageData(ab_person)
+      UIImage.alloc.initWithData(abpd)
     end
 
     def photo=(photo_data)


### PR DESCRIPTION
Fixes https://github.com/alexrothenberg/motion-addressbook/issues/29

Prevents crash in REPL when calling person.photo. ABPersonCopyImageData(ab_person) returns an NSCFData instance which can't be displayed in the REPL.
