### PR TITLE
Sorting the address book using Apple's recommended method

### DIFF
--- a/motion/address_book/ios/person.rb
+++ b/motion/address_book/ios/person.rb
@@ -18,10 +18,11 @@ module AddressBook
       ab_people = ABAddressBookCopyArrayOfAllPeople(ab)
       return [] if ab_people.nil?
 
+      o = ABPersonGetSortOrdering()
+      ab_people.sort! { |x, y| ABPersonComparePeopleByName(x, y, o)  }
       people = ab_people.map do |ab_person|
         new({}, ab_person, :address_book => ab)
       end
-      people.sort! { |a,b| "#{a.first_name} #{a.last_name}" <=> "#{b.first_name} #{b.last_name}" }
       people
     end
 


### PR DESCRIPTION
Hello, 

the current sorting method for the contacts is quite slow currently. It takes 6 seconds for approximatively 1000 contacts on my iPhone 5. 

I guess the problem is the creation of one string per user but I did not investigate fully on this side. 

I send you this pull request that uses the function provided by Apple to compare contacts. The speed of the sort after this modification went from 6s to 0,06s on my iPhone 5. 

I hope that you will like it. 

Martin
