### PR TITLE
try not to crash if AB authorization is denied

### DIFF
--- a/lib/motion-addressbook/version.rb
+++ b/lib/motion-addressbook/version.rb
@@ -1,5 +1,5 @@
 module Motion
   module Addressbook
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end

--- a/motion/address_book/ios/addr_book.rb
+++ b/motion/address_book/ios/addr_book.rb
@@ -2,16 +2,34 @@ module AddressBook
   class AddrBook
     attr_reader :ab
 
-    def initialize
-      if AddressBook.authorized?
-        @ab = AddressBook.address_book
+    def initialize(&block)
+      @ab = NullAddrBook
+      if authorized?
+        activate!
+        if block_given?
+          yield self
+        end
+      elsif block
+        # asynchronous auth
+        AddressBook.request_authorization do |granted|
+          if granted
+            activate!
+            block.call(self)
+          end
+        end
       else
-        AddressBook.request_authorization { @ab = AddressBook.address_book }
+        # synchronous auth
+        if native_ab = AddressBook.address_book
+          @ab = LiveAddrBook.new(native_ab)
+        end
       end
     end
 
+    def activate!
+      @ab = LiveAddrBook.new(AddressBook.address_book)
+    end
     def authorized?
-      AddressAddressBook.authorized?
+      AddressBook.authorized?
     end
 
     def auth!
@@ -19,10 +37,7 @@ module AddressBook
     end
 
     def people(opts = {}, &block)
-      auth!
-      ordered_list = ab_people(opts).map do |ab_person|
-        AddressBook::Person.new({}, ab_person, :address_book => ab)
-      end
+      ordered_list = ab_people(opts).map { |p| Person.new(nil, p, address_book: ab.ab) }
       if block
         ordered_list.sort_by { |p| block.call(p) }
       else
@@ -30,11 +45,10 @@ module AddressBook
       end
     end
     def count
-      ABAddressBookGetPersonCount(@ab)
+      ab.person_count
     end
     def new_person(attributes)
-      auth!
-      Person.new(attributes, nil, :address_book => @ab)
+      Person.new(attributes, nil, :address_book => ab.ab)
     end
     def create_person(attributes)
       p = new_person(attributes)
@@ -42,35 +56,37 @@ module AddressBook
       p
     end
     def person(id)
-      auth!
-      (p = ABAddressBookGetPersonWithRecordID(ab, id)) && Person.new(nil, p, :address_book => ab)
+      (p = ab.person_with_id(id)) && Person.new(nil, p, :address_book => ab.ab)
     end
     def changedSince(timestamp)
       people.select {|p| p.modification_date > timestamp}
     end
 
     def groups
-      auth!
-      ABAddressBookCopyArrayOfAllGroups(@ab).map do |ab_group|
-        AddressBook::Group.new(:ab_group => ab_group, :address_book => @ab)
+      ab.all_groups.map do |ab_group|
+        AddressBook::Group.new(:ab_group => ab_group, :address_book => ab.ab)
       end
     end
     def group_count
-      ABAddressBookGetGroupCount(@ab)
+      ab.group_count
     end
     def new_group(attributes)
-      AddressBook::Group.new(:attributes => attributes, :address_book => @ab)
+      AddressBook::Group.new(:attributes => attributes, :address_book => ab.ab)
     end
     def group(id)
-      (g = ABAddressBookGetGroupWithRecordID(ab, id)) && Group.new(:ab_group => g, :address_book => @ab)
+      (g = ab.group_with_id(id)) && Group.new(:ab_group => g, :address_book => ab.ab)
     end
 
     def notify_changes(callback, context)
-      ABAddressBookRegisterExternalChangeCallback(ab, callback, context)
+      ab.register_callback(callback, context)
     end
 
     def sources
-      ABAddressBookCopyArrayOfAllSources(ab).map {|s| Source.new(s)}
+      ab.sources.map {|s| Source.new(s)}
+    end
+
+    def inspect
+      "#<#{self.class}:#{"0x%0x" % object_id} #{ab.status}>"
     end
 
     private
@@ -80,13 +96,55 @@ module AddressBook
       ordering = opts.fetch(:ordering) { ABPersonGetSortOrdering() }
 
       ab_people = if ab_source
-                    ABAddressBookCopyArrayOfAllPeopleInSource(ab, ab_source)
+                    ab.all_people_in_source(ab_source)
                   else
-                    ABAddressBookCopyArrayOfAllPeople(ab)
+                    ab.all_people
                   end
 
       ab_people.sort! { |x, y| ABPersonComparePeopleByName(x, y, ordering)  }
       ab_people
+    end
+  end
+
+  class NullAddrBook
+    def self.status; "pending"; end
+    def self.method_missing(*args)
+      raise SecurityError, "iOS Address Book authorization is required."
+    end
+  end
+
+  class LiveAddrBook
+    attr_reader :ab
+    def initialize(ab)
+      @ab = ab
+    end
+    def status; "live"; end
+    def all_people
+      ABAddressBookCopyArrayOfAllPeople(ab)
+    end
+    def all_people_in_source(source)
+      ABAddressBookCopyArrayOfAllPeopleInSource(ab, source)
+    end
+    def person_with_id(id)
+      ABAddressBookGetPersonWithRecordID(ab, id)
+    end
+    def person_count
+      ABAddressBookGetPersonCount(ab)
+    end
+    def all_groups
+      ABAddressBookCopyArrayOfAllGroups(ab)
+    end
+    def group_count
+      ABAddressBookGetGroupCount(ab)
+    end
+    def group_with_id(id)
+      ABAddressBookGetGroupWithRecordID(ab, id)
+    end
+    def sources
+      ABAddressBookCopyArrayOfAllSources(ab)
+    end
+    def register_callback(callback, context)
+      ABAddressBookRegisterExternalChangeCallback(ab, callback, context)
     end
   end
 end

--- a/motion/address_book/ios/group.rb
+++ b/motion/address_book/ios/group.rb
@@ -5,23 +5,12 @@
 #
 module AddressBook
   class Group
-    attr_reader :attributes, :error
+    attr_reader :attributes, :error, :address_book
 
     def initialize(opts)
-      @address_book = opts[:address_book]
-      if opts[:ab_group]
-        # import existing
-        @ab_group = opts[:ab_group]
-        @attributes = nil
-      else
-        # create new
-        @ab_group = nil
-        @attributes = opts[:attributes]
-      end
-    end
-
-    def address_book
-      @address_book ||= AddressBook.address_book
+      @address_book = opts.fetch(:address_book) { AddressBook.address_book }
+      @ab_group = opts[:ab_group]
+      @attributes = opts[:attributes]
     end
 
     def save
@@ -57,6 +46,9 @@ module AddressBook
 
     def name
       ABRecordCopyValue(ab_group, KABGroupNameProperty)
+    end
+    def name=(newname)
+      ABRecordSetValue(ab_group, KABGroupNameProperty, newname, error)
     end
 
     def size

--- a/motion/address_book/ios/multi_valued.rb
+++ b/motion/address_book/ios/multi_valued.rb
@@ -1,5 +1,7 @@
 module AddressBook
   class MultiValued
+    include Enumerable
+
     attr_reader :mv_type
 
     def initialize(opts)
@@ -23,6 +25,19 @@ module AddressBook
     def attributes
       @attributes ||= convert_multi_value_into_dictionary
     end
+    def to_ary
+      attributes
+    end
+    def [](index)
+      attributes[index]
+    end
+    def each
+      attributes.each { |i| yield i }
+    end
+    def to_s
+      "#<#{self.class}: #{attributes}>"
+    end
+    alias :inspect :to_s
 
     def convert_multi_value_into_dictionary
       count.times.map do |i|

--- a/motion/address_book/osx/addr_book.rb
+++ b/motion/address_book/osx/addr_book.rb
@@ -46,6 +46,9 @@ module AddressBook
         AddressBook::Group.new(:ab_group => ab_group, :address_book => @ab)
       end
     end
+    def group_count
+      groups.count
+    end
     def new_group(attributes)
       AddressBook::Group.new(:attributes => attributes, :address_book => @ab)
     end
@@ -61,9 +64,8 @@ module AddressBook
       end
     end
 
-    # def sources
-    #   # ABAddressBookCopyArrayOfAllSources(ab).map {|s| ABRecordCopyValue(s, KABSourceTypeProperty)}
-    #   ABAddressBookCopyArrayOfAllSources(ab).map {|s| Source.new(s)}
-    # end
+    def inspect
+      "#<#{self.class}:#{"0x%0x" % object_id} #{count} people, #{group_count} groups>"
+    end
   end
 end

--- a/motion/address_book/osx/multi_valued.rb
+++ b/motion/address_book/osx/multi_valued.rb
@@ -1,5 +1,7 @@
 module AddressBook
   class MultiValued
+    include Enumerable
+
     attr_reader :mv_type
 
     def initialize(opts)
@@ -23,6 +25,19 @@ module AddressBook
     def attributes
       @attributes ||= convert_multi_value_into_dictionary
     end
+    def to_ary
+      attributes
+    end
+    def [](index)
+      attributes[index]
+    end
+    def each
+      attributes.each { |i| yield i }
+    end
+    def to_s
+      "#<#{self.class}: #{attributes}>"
+    end
+    alias :inspect :to_s
 
     def convert_multi_value_into_dictionary
       count.times.map do |i|

--- a/motion/address_book/osx/person.rb
+++ b/motion/address_book/osx/person.rb
@@ -1,9 +1,10 @@
 module AddressBook
   class Person
     attr_reader :error
+    attr_reader :address_book
 
     def initialize(target, opts = {})
-      @address_book = opts[:address_book]
+      @address_book = opts.fetch(:address_book) { AddressBook.address_book }
       if target.respond_to?(:fetch)
         # data for a new Person, to be saved to the Address Book
         @ab_person = nil
@@ -111,6 +112,8 @@ module AddressBook
     def get_multi_valued(field)
       if mv = get_field(field)
         MultiValued.new(:ab_multi_value => mv)
+      else
+        []
       end
     end
 
@@ -318,7 +321,7 @@ module AddressBook
 
       MultiValuePropertyMap.each do |ab_property, attr_key|
         if value = get_multi_valued(ab_property)
-          if value.attributes.any?
+          if value.any?
             @attributes[attr_key] = value.attributes
           end
         end
@@ -345,10 +348,6 @@ module AddressBook
         multi_field = MultiValued.new(:attributes => values)
         set_field(field, multi_field.ab_multi_value)
       end
-    end
-
-    def address_book
-      @address_book ||= AddressBook.address_book
     end
   end
 end

--- a/spec/ios/address_book/person_spec.rb
+++ b/spec/ios/address_book/person_spec.rb
@@ -3,6 +3,10 @@ describe AddressBook::Person do
     @ab = AddressBook::AddrBook.new
   end
 
+  it "should be authorized" do
+    @ab.authorized?.should.be.true
+  end
+
   describe 'ways of creating and finding people' do
     describe 'new' do
       before do


### PR DESCRIPTION
Found various ways to crash apps on AB calls if the user does not give AB access permission or if calls are attempted while the access popup is still waiting. I probably haven't caught all the edge cases.

Also various refactorings, in particular nicer access to the multi-valued properties.
