### PR TITLE
Safer, more explicit photo accessors 

### DIFF
--- a/motion/address_book/ios/person.rb
+++ b/motion/address_book/ios/person.rb
@@ -191,11 +191,11 @@ module AddressBook
     end
 
     def photo_image
-      UIImage.alloc.initWithData(photo)
+      ABPersonHasImageData(ab_person) ? UIImage.alloc.initWithData(photo) : nil
     end
 
     def photo
-      ABPersonCopyImageData(ab_person)
+      ABPersonHasImageData(ab_person) ? ABPersonCopyImageData(ab_person) : nil
     end
 
     def photo=(photo_data)


### PR DESCRIPTION
This shouldn't be needed, as https://developer.apple.com/library/ios/documentation/AddressBook/Reference/ABPersonRef_iPhoneOS/Reference/reference.html#//apple_ref/doc/uid/TP40007210-CH3-SW12 states "The picture for person, or NULL if the person has no picture."  but i'm seeing crashes here, lets just be extra explicit here anyways. 

It's also probably not wise to pass back a corrupt UIImage object `initWithData(nil)` when there is no image available. Most callees would expect nil here, not a `UIImage` object when there is no photo
