### PR TITLE
Remove bubblewrap as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 
-# need to do this here as alphabetically "bubble-wrap" comes after "address_book" and require fails otherwise
-gem 'bubble-wrap', '~> 1.3'
-
 # Specify your gem's dependencies in motion-addressbook.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ notification.
 ```ruby
 ab.observe!
 
+proc = Proc.new {|notification| NSLog "Address Book was changed!" }
+NSNotificationCenter.defaultCenter.addObserverForName(:addressbook_updated, object:nil, queue:NSOperationQueue.mainQueue, usingBlock:proc)
+
+# Or using BubbleWrap:
 App.notification_center.observe :addressbook_updated do |notification|
   NSLog "Address Book was changed!"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,20 +10,15 @@ end
 Bundler.setup
 Bundler.require
 
-require 'bubble-wrap/reactor'
-
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'AddressBook'
 
-  if Motion::Project::App.osx?
+  if ENV['osx']
     app.specs_dir = "./spec/osx"
+    app.info_plist['LSUIElement'] = true
   else
     app.specs_dir = "./spec/ios"
-  end
-
-  if ENV['osx']
-    app.info_plist['LSUIElement'] = true
   end
 end
 

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -15,9 +15,11 @@ class AppDelegate
       AddressBook::AddrBook.new do |ab|
         case command
         when 'people'
-          puts BW::JSON.generate(ab.people.map(&:attributes))
+          people = ab.people.map(&:attributes)
+          puts NSJSONSerialization.dataWithJSONObject(people, options:0, error:nil).to_str
         when 'groups'
-          puts BW::JSON.generate(ab.groups.map { |g| {name: g.name, members: g.members.map(&:uid) }})
+          groups = ab.groups.map { |g| {name: g.name, members: g.members.map(&:uid) }}
+          puts NSJSONSerialization.dataWithJSONObject(groups, options:0, error:nil).to_str
         end
       end
     end

--- a/lib/motion-addressbook.rb
+++ b/lib/motion-addressbook.rb
@@ -19,12 +19,12 @@ Motion::Project::App.setup do |app|
   app.frameworks += ['AddressBook']
   app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book.rb")))
 
-  if !Motion::Project::App.osx?
+  if app.respond_to?(:template) && app.template == :osx
+    # We have an OS X project
+    app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book/osx/**.rb")))
+  else
     # We have an iOS project
     app.frameworks += ['AddressBookUI']
     app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book/ios/**.rb")))
-  else
-    # We have an OS X project
-    app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book/osx/**.rb")))
   end
 end

--- a/lib/motion-addressbook.rb
+++ b/lib/motion-addressbook.rb
@@ -1,5 +1,4 @@
 require "motion-addressbook/version"
-require "bubble-wrap/core"
 
 # RubyMotion bug RM-81 was fixed for 2.8; motion-addressbook
 if Gem::Version.new(Motion::Version) < Gem::Version.new("2.8")
@@ -14,30 +13,18 @@ gem 'motion-addressbook', '<= 1.5.0'
 EOT
 end
 
-BubbleWrap.require 'motion/address_book.rb' do
-  file('motion/address_book.rb').uses_framework('AddressBook')
-end
+lib_dir_path = File.dirname(File.expand_path(__FILE__))
+Motion::Project::App.setup do |app|
 
-BubbleWrap.require_ios do
-  # BW.require 'motion/address_book/multi_value.rb'
-  BW.require 'motion/address_book/ios/addr_book.rb'
-  BW.require 'motion/address_book/ios/person.rb'
-  BW.require 'motion/address_book/ios/group.rb'
-  BW.require 'motion/address_book/ios/multi_valued.rb'
-  BW.require 'motion/address_book/ios/source.rb'
+  app.frameworks += ['AddressBook']
+  app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book.rb")))
 
-  BW.require 'motion/address_book/ios/picker.rb' do
-    file('motion/address_book/ios/picker.rb').uses_framework('AddressBookUI')
+  if !Motion::Project::App.osx?
+    # We have an iOS project
+    app.frameworks += ['AddressBookUI']
+    app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book/ios/**.rb")))
+  else
+    # We have an OS X project
+    app.files.unshift(Dir.glob(File.join(lib_dir_path, "../motion/address_book/osx/**.rb")))
   end
-  BW.require 'motion/address_book/ios/creator.rb' do
-    file('motion/address_book/ios/creator.rb').uses_framework('AddressBookUI')
-  end
-end
-
-BubbleWrap.require_osx do
-  BW.require 'motion/address_book/osx/addr_book.rb'
-  BW.require 'motion/address_book/osx/person.rb'
-  BW.require 'motion/address_book/osx/group.rb'
-  BW.require 'motion/address_book/osx/multi_valued.rb'
-  BW.require 'motion/address_book/osx/source.rb'
 end

--- a/motion-addressbook.gemspec
+++ b/motion-addressbook.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'bubble-wrap', '~> 1.3'
-
+  gem.add_development_dependency 'bubble-wrap', '~> 1.3'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
 end

--- a/motion-addressbook.gemspec
+++ b/motion-addressbook.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency 'bubble-wrap', '~> 1.3'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
 end

--- a/motion/address_book.rb
+++ b/motion/address_book.rb
@@ -2,10 +2,10 @@ module AddressBook
   module_function
 
   def address_book
-    if App.osx?
+    if Kernel.const_defined?(:NSApplication)
       ABAddressBook.addressBook
     else # iOS
-      if Device.ios_version =~ /5/
+      if UIDevice.currentDevice.systemVersion =~ /5/
         ios5_create
       else
         ios6_create
@@ -18,7 +18,7 @@ module AddressBook
   end
 
   def count
-    if App.ios?
+    if Kernel.const_defined?(:UIApplication)
       # ABAddressBookGetPersonCount(address_book)
       instance.count
     else

--- a/motion/address_book/ios/addr_book.rb
+++ b/motion/address_book/ios/addr_book.rb
@@ -37,7 +37,7 @@ module AddressBook
 
     def observe!
       @notifier = Proc.new do |ab_instance, always_nil, context|
-        App.notification_center.post :addressbook_updated, self
+        NSNotificationCenter.defaultCenter.postNotificationName(:addressbook_updated, object: self, userInfo: nil)
       end
       ab.register_callback(@notifier)
     end

--- a/motion/address_book/osx/addr_book.rb
+++ b/motion/address_book/osx/addr_book.rb
@@ -60,9 +60,10 @@ module AddressBook
     end
 
     def observe!
-      App.notification_center.observe KABDatabaseChangedExternallyNotification do |notification|
-        App.notification_center.post :addressbook_updated, self
+      proc = Proc.new do |notification|
+        NSNotificationCenter.defaultCenter.postNotificationName(:addressbook_updated, object: self, userInfo: nil)
       end
+      NSNotificationCenter.defaultCenter.addObserverForName(KABDatabaseChangedExternallyNotification, object:nil, queue:NSOperationQueue.mainQueue, usingBlock:proc)
     end
 
     def inspect

--- a/spec/ios/address_book/person_spec.rb
+++ b/spec/ios/address_book/person_spec.rb
@@ -530,9 +530,9 @@ describe AddressBook::Person do
       @ab1.observe!
       @ab2.observe!
       @notifications = 0
-      App.notification_center.observe :addressbook_updated do |notification|
-        @notifications += 1
-      end
+
+      proc = Proc.new{|notification| @notifications += 1 }
+      NSNotificationCenter.defaultCenter.addObserverForName(:addressbook_updated, object:nil, queue:NSOperationQueue.mainQueue, usingBlock:proc)
     end
 
     # should see a single notification for each change to the AB database:

--- a/spec/ios/helpers/spec_helper.rb
+++ b/spec/ios/helpers/spec_helper.rb
@@ -6,9 +6,10 @@ module Bacon
     def ab_connect
       AddressBook::AddrBook.new do |ab|
         if ab
-          EM.schedule_on_main do
+          cb = proc do
             Bacon.run
           end
+          Dispatch::Queue.main.async &cb
         else
           warn "ACCESS DENIED - ABORTING"
           exit


### PR DESCRIPTION
1. Required all files and frameworks without bubble wrap
2. Removed all instances of `App.` and `Device.` and converted them to their non-bubblewrap counterparts
3. Converted app `App.notification_center` to use `NSNotificationCenter` counterparts.

Specs are still failing on my machine on iOS 8 but they're the exact same failures as on `master`

Closes #74 

I'd suggest testing this heavily before merging. :beers: 