### PR TITLE
Fix issue of attempting to alter frozen array in iOS 11

### DIFF
--- a/motion/address_book/ios/addr_book.rb
+++ b/motion/address_book/ios/addr_book.rb
@@ -123,7 +123,7 @@ module AddressBook
                     ab.all_people
                   end
 
-      ab_people.sort! { |x, y| ABPersonComparePeopleByName(x, y, ordering)  }
+      ab_people = ab_people.sort { |x, y| ABPersonComparePeopleByName(x, y, ordering)  }
       ab_people
     end
   end


### PR DESCRIPTION
In iOS 11, this library fails because the `abpeople` array is frozen, and the in-place sort attempts to alter a frozen array. This change replaces the in-place sort with a reassignment to fix the issue.